### PR TITLE
Reorganize router/adapter config files

### DIFF
--- a/config/example.router.json
+++ b/config/example.router.json
@@ -3,12 +3,28 @@
     "httpbin": {
       "type": "rest",
       "base_url": "https://httpbin.org",
-      "config_file": "config/httpbin.rest.adapter.json"
+      "headers": {
+        "User-Agent": "DataAgents-Test/1.0"
+      },
+      "timeout": 10,
+      "endpoints": ["json", "headers", "user-agent"],
+      "pagination_param": null,
+      "pagination_limit": null
     },
     "jsonplaceholder": {
       "type": "rest", 
       "base_url": "https://jsonplaceholder.typicode.com",
-      "config_file": "config/jsonplaceholder.rest.adapter.json"
+      "headers": {
+        "User-Agent": "DataAgents-Test/1.0"
+      },
+      "timeout": 10,
+      "endpoints": [
+        "users",
+        "posts",
+        "comments"
+      ],
+      "pagination_param": "_limit",
+      "pagination_limit": 3
     },
     "sample_data": {
       "type": "tabular",

--- a/config/example.router.yaml
+++ b/config/example.router.yaml
@@ -2,17 +2,30 @@ adapters:
   httpbin:
     type: rest
     base_url: https://httpbin.org
-    config_file: config/httpbin.rest.adapter.json
-    
+    headers:
+      User-Agent: DataAgents-Test/1.0
+    timeout: 10
+    endpoints:
+      - json
+      - headers
+      - user-agent
+    pagination_param: null
+    pagination_limit: null
+
   jsonplaceholder:
     type: rest
     base_url: https://jsonplaceholder.typicode.com
-    config_file: config/jsonplaceholder.rest.adapter.json
-    
+    headers:
+      User-Agent: DataAgents-Test/1.0
+    timeout: 10
+    endpoints:
+      - users
+      - posts
+      - comments
+    pagination_param: _limit
+    pagination_limit: 3
+
   sample_data:
     type: tabular
     csv_file: examples/sample_data.csv
     
-  employees:
-    type: tabular
-    csv_file: examples/sample_data.csv

--- a/config/httpbin.adapter.json
+++ b/config/httpbin.adapter.json
@@ -1,4 +1,6 @@
 {
+    "type": "rest",
+    "base_url": "https://httpbin.org",
     "headers": {
         "User-Agent": "DataAgents-Test/1.0"
     },

--- a/config/jsonplaceholder.adapter.json
+++ b/config/jsonplaceholder.adapter.json
@@ -1,5 +1,15 @@
 {
-  "type": "rest",
-  "base_url": "https://jsonplaceholder.typicode.com",
-  "config_file": "config/jsonplaceholder.rest.adapter.json"
+    "type": "rest",
+    "base_url": "https://jsonplaceholder.typicode.com",
+    "headers": {
+        "User-Agent": "DataAgents-Test/1.0"
+    },
+    "timeout": 10,
+    "endpoints": [
+        "users",
+        "posts",
+        "comments"
+    ],
+    "pagination_param": "_limit",
+    "pagination_limit": 3
 }

--- a/config/jsonplaceholder.rest.adapter.json
+++ b/config/jsonplaceholder.rest.adapter.json
@@ -1,9 +1,0 @@
-{
-    "headers": {
-        "User-Agent": "DataAgents-Test/1.0"
-    },
-    "timeout": 10,
-    "endpoints": ["users", "posts", "comments"],
-    "pagination_param": "_limit",
-    "pagination_limit": 3
-}

--- a/config/nasapower.adapter.json
+++ b/config/nasapower.adapter.json
@@ -1,3 +1,5 @@
 {
+    "type": "rest",
+    "base_url": "https://power.larc.nasa.gov/api/temporal/daily",
     "openapi_data": [ "https://power.larc.nasa.gov/api/temporal/daily/openapi.json" ]
 }

--- a/config/rest_countries.adapter.json
+++ b/config/rest_countries.adapter.json
@@ -1,4 +1,6 @@
 {
+    "type": "rest",
+    "base_url": "https://restcountries.com",
     "headers": {
         "User-Agent": "DataAgents-Test/1.0"
     },

--- a/docs/CLI_ROUTER_CONFIG.md
+++ b/docs/CLI_ROUTER_CONFIG.md
@@ -16,7 +16,10 @@ The router configuration file should contain an `adapters` section that defines 
     "api_data": {
       "type": "rest",
       "base_url": "https://api.example.com",
-      "config_file": "path/to/rest_config.json"
+      "headers": {
+        "User-Agent": "DataAgents-test/1.0"
+      },
+      "endpoints": ["foo", "bar"]
     },
     "csv_data": {
       "type": "tabular",
@@ -50,7 +53,7 @@ You can also create configuration files for individual adapters:
 {
   "type": "rest",
   "base_url": "https://jsonplaceholder.typicode.com",
-  "config_file": "config/jsonplaceholder.rest.adapter.json"
+  "config_file": "config/jsonplaceholder.adapter.json"
 }
 ```
 
@@ -159,5 +162,5 @@ See the following example files in the repository:
 - `config/example.router.yaml` - Complete YAML router configuration example
 - `config/jsonplaceholder.adapter.json` - Single adapter configuration example
 - `examples/sample_data.csv` - Sample CSV file for testing
-- `config/jsonplaceholder.rest.adapter.json` - Example REST adapter configuration
-- `config/httpbin.rest.adapter.json` - Another REST adapter configuration example
+- `config/jsonplaceholder.adapter.json` - Example REST adapter configuration
+- `config/httpbin.adapter.json` - Another REST adapter configuration example

--- a/src/data_agents/cli.py
+++ b/src/data_agents/cli.py
@@ -83,22 +83,13 @@ def create_adapter_from_config(
 
     if adapter_type == "rest":
         base_url = adapter_config.get("base_url")
-        config_file = adapter_config.get("config_file")
 
         if not base_url:
             print("Error: REST adapter missing required 'base_url'")
             return None
 
-        # Load REST adapter configuration if provided
-        rest_config = {}
-        if config_file:
-            try:
-                rest_config = load_config_file(config_file)
-            except (FileNotFoundError, ValueError) as e:
-                print(f"Warning: Failed to load REST adapter config: {e}")
-
         try:
-            return RESTAdapter(base_url, rest_config)
+            return RESTAdapter(base_url, adapter_config)
         except Exception as e:
             print(f"Error: Failed to create REST adapter: {e}")
             return None

--- a/tests/adapters/test_rest_adapter.py
+++ b/tests/adapters/test_rest_adapter.py
@@ -786,7 +786,7 @@ class TestRESTAdapterIntegration:
 
     def test_httpbin_integration(self):
         """Test RESTAdapter with httpbin.org API."""
-        config = load_config("httpbin.rest.adapter.json")
+        config = load_config("httpbin.adapter.json")
 
         adapter = RESTAdapter("https://httpbin.org", config)
 
@@ -828,7 +828,7 @@ class TestRESTAdapterIntegration:
 
     def test_rest_countries_integration(self):
         """Test RESTAdapter with REST Countries API."""
-        config = load_config("rest_countries.rest.adapter.json")
+        config = load_config("rest_countries.adapter.json")
 
         adapter = RESTAdapter("https://restcountries.com", config)
 
@@ -871,7 +871,7 @@ class TestRESTAdapterIntegration:
 
     def test_jsonplaceholder_integration(self):
         """Test RESTAdapter with JSONPlaceholder API (original working example)."""
-        config = load_config("jsonplaceholder.rest.adapter.json")
+        config = load_config("jsonplaceholder.adapter.json")
 
         adapter = RESTAdapter("https://jsonplaceholder.typicode.com", config)
 
@@ -997,7 +997,7 @@ class TestRESTAdapterIntegration:
     def test_nasa_power_openapi_integration(self):
         """Test RESTAdapter with NASA Power API using OpenAPI specification."""
         try:
-            config = load_config("nasapower.rest.adapter.json")
+            config = load_config("nasapower.adapter.json")
             adapter = RESTAdapter("https://power.larc.nasa.gov/api", config)
 
             # Test that OpenAPI spec was loaded and endpoints were discovered

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -376,18 +376,6 @@ class TestCLIAdapterCreation:
         finally:
             os.unlink(rest_config_file)
 
-    def test_create_adapter_from_config_rest_invalid_config_file(self, capsys):
-        """Test creating REST adapter with invalid config file."""
-        config = {
-            "type": "rest",
-            "base_url": "https://api.example.com",
-            "config_file": "nonexistent.json",
-        }
-        adapter = create_adapter_from_config(config)
-        assert adapter is not None  # Should still create adapter with warning
-        captured = capsys.readouterr()
-        assert "Warning: Failed to load REST adapter config" in captured.out
-
     def test_create_adapter_from_config_rest_creation_error(self, capsys):
         """Test REST adapter creation failure."""
         config = {

--- a/tests/test_cli_router_config.py
+++ b/tests/test_cli_router_config.py
@@ -64,7 +64,7 @@ class TestCLIRouterConfigExamples:
         rest_config = {
             "type": "rest",
             "base_url": "https://jsonplaceholder.typicode.com",
-            "config_file": "config/jsonplaceholder.rest.adapter.json",
+            "config_file": "config/jsonplaceholder.adapter.json",
         }
 
         assert rest_config["type"] == "rest"
@@ -102,8 +102,8 @@ class TestCLIRouterConfigExamples:
             "config/example.router.yaml",
             "config/jsonplaceholder.adapter.json",
             "examples/sample_data.csv",
-            "config/jsonplaceholder.rest.adapter.json",
-            "config/httpbin.rest.adapter.json",
+            "config/jsonplaceholder.adapter.json",
+            "config/httpbin.adapter.json",
         ]
 
         for file_path in expected_files:


### PR DESCRIPTION
This PR modifies the config files used by the CLI to include all REST adapter configuration information in a router config file (instead of referencing a separate config file for each REST adapter), and to include the type and base URL in adapter configuration files